### PR TITLE
Bug Fix : Enabled Filter by C#, Java & C++

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,5 +1,5 @@
 GITHUB_TOKEN=
 # (In hours)
 REPO_CACHE_TIME=8
-MONGODB_URI=
+MONGODB_URI=mongodb+srv://vdnh123:abc123456@atlascluster.4qkviv9.mongodb.net/firstIssue
 CRON_SECRET=

--- a/.env.local
+++ b/.env.local
@@ -1,5 +1,5 @@
 GITHUB_TOKEN=
 # (In hours)
 REPO_CACHE_TIME=8
-MONGODB_URI=mongodb+srv://vdnh123:abc123456@atlascluster.4qkviv9.mongodb.net/firstIssue
+MONGODB_URI=
 CRON_SECRET=

--- a/app/api/project/route.ts
+++ b/app/api/project/route.ts
@@ -1,6 +1,7 @@
 import Project from '@/models/Project';
 import mongoose from 'mongoose';
 import { NextRequest, NextResponse } from 'next/server';
+import { Repo } from '@/schema';
 
 export const GET = async (req: NextRequest) => {
   try {
@@ -12,7 +13,10 @@ export const GET = async (req: NextRequest) => {
     const limit = parseInt(url.searchParams.get("limit") || "100");
 
     const query: any = {};
-    if (lang) {
+    if(lang==='c++'){
+      query.language={$regex: new RegExp('c\\+\\+', "i")}
+    }
+    else {
       query.language = { $regex: new RegExp(lang, "i") }; 
     }
 
@@ -37,12 +41,19 @@ export const GET = async (req: NextRequest) => {
       .limit(limit)
       .exec();
 
+      let paginatedDataUpdated=paginatedData;
+      if(lang!=''){
+        paginatedDataUpdated=paginatedData.filter((item:Repo)=>{
+          return item.language.toLowerCase()===lang
+         })
+      }
+
     const response = {
       total: totalRecords,
       pages: totalPages,
       current: page,
       recordsPerPage: limit,
-      data: paginatedData,
+      data: paginatedDataUpdated,
     };
 
     return new NextResponse(JSON.stringify(response), { status: 200 });

--- a/components/List.tsx
+++ b/components/List.tsx
@@ -22,6 +22,9 @@ interface Props {
 }
 
 const List = ({ langFilter, sortFilter }: Props) => {
+
+  langFilter = encodeURIComponent(langFilter);
+
   const { isLoading, data: repos } = useFetch<Repo[]>({
     url: `/api/project?lang=${langFilter}&sort_by=${sortFilter.value}&order=${sortFilter.order}`,
   });


### PR DESCRIPTION
1. As In this repository, we are dealing with the special characters used in the languages like C#,C++.Hence we were not able 
to fetch the langfilter correctly when the langFilter contains the special character.
url: `/api/project?lang=${langFilter}&sort_by=${sortFilter.value}&order=${sortFilter.order}`.


2. So I have encoded the langFilter before fetching the data using the encodeURIComponent() function,
     
![image](https://github.com/user-attachments/assets/5f6cc959-76ee-4663-8de8-90e19d2848ad)

3.Then I have used the filter statement to filter out the records which are coming from the mongoDb,because for an language C we are getting all the records where C is the prefix so I have filtered those records.
![image](https://github.com/user-attachments/assets/7391a4a2-562d-4708-b7c8-823b052319d8)

4.For the language C++, As it contains the extra special Character '++', its regex was not matching while quering the database. So for this I have created a manual regex to match the records where the language is 'C++'
![image](https://github.com/user-attachments/assets/cd050327-8c08-4c71-900b-4c29af0add93)


I have tested out all the cases and getting the records as per the expectation.
![image](https://github.com/user-attachments/assets/187530ff-1be1-472f-9893-0686019b682b)
![image](https://github.com/user-attachments/assets/e5ffecd9-ff3d-49d8-9486-c0355adfc184)




